### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,13 @@
 name: "CI: Build and Test"
 
+permissions:
+  contents: read
+
 on:
   pull_request:
     branches: [main]
   push:
     branches: [main]
-
-jobs:
-  dotnet-format:
     name: .Net Format Check
     runs-on: ubuntu-latest
 


### PR DESCRIPTION
Potential fix for [https://github.com/brandonhenricks/serilog-enricher-xperience/security/code-scanning/3](https://github.com/brandonhenricks/serilog-enricher-xperience/security/code-scanning/3)

To fix the issue, we will add a `permissions` block to the root of the workflow. This block will define the minimal permissions required for the workflow to function. Based on the provided steps, the workflow primarily interacts with the repository contents (e.g., checking out code and restoring dependencies). Therefore, the `contents: read` permission is sufficient. If additional permissions are required for specific jobs, they can be defined within those jobs.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
