### PR TITLE
Update Microsoft.SourceLink.GitHub package version

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -6,7 +6,7 @@
     <DisableImplicitNuGetFallbackFolder>true</DisableImplicitNuGetFallbackFolder>
   </PropertyGroup>
   <ItemGroup>
-    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="[8.0.0.0,)" />
+    <PackageVersion Include="Microsoft.SourceLink.GitHub" Version="8.0.0" />
     <PackageVersion Include="Kentico.Xperience.WebApp" Version="[30.0.0,)" />
     <PackageVersion Include="Serilog" Version="[4.0.0,)" />
     <PackageVersion Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="[8.0.0.0,)" />

--- a/src/Serilog.Enrichers.Xperience/Serilog.Enrichers.Xperience.csproj
+++ b/src/Serilog.Enrichers.Xperience/Serilog.Enrichers.Xperience.csproj
@@ -5,7 +5,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Serilog" />
+    <PackageReference Include="Microsoft.SourceLink.GitHub">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Serilog">
+		<PrivateAssets>all</PrivateAssets>
+	</PackageReference>
   </ItemGroup>
 
   <ItemGroup>

--- a/src/Serilog.Enrichers.Xperience/packages.lock.json
+++ b/src/Serilog.Enrichers.Xperience/packages.lock.json
@@ -18,6 +18,16 @@
           "System.Text.Json": "8.0.5"
         }
       },
+      "Microsoft.SourceLink.GitHub": {
+        "type": "Direct",
+        "requested": "[8.0.0, )",
+        "resolved": "8.0.0",
+        "contentHash": "G5q7OqtwIyGTkeIOAc3u2ZuV/kicQaec5EaRnc0pIeSnh9LUjj+PYQrJYBURvDt7twGl2PKA7nSN0kz1Zw5bnQ==",
+        "dependencies": {
+          "Microsoft.Build.Tasks.Git": "8.0.0",
+          "Microsoft.SourceLink.Common": "8.0.0"
+        }
+      },
       "Serilog": {
         "type": "Direct",
         "requested": "[4.0.0, )",
@@ -393,6 +403,11 @@
         "resolved": "1.1.1",
         "contentHash": "yuvf07qFWFqtK3P/MRkEKLhn5r2UbSpVueRziSqj0yJQIKFwG1pq9mOayK3zE5qZCTs0CbrwL9M6R8VwqyGy2w=="
       },
+      "Microsoft.Build.Tasks.Git": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "bZKfSIKJRXLTuSzLudMFte/8CempWjVamNUR5eHJizsy+iuOuO/k2gnh7W0dHJmYY0tBf+gUErfluCv5mySAOQ=="
+      },
       "Microsoft.CSharp": {
         "type": "Transitive",
         "resolved": "4.5.0",
@@ -657,6 +672,11 @@
         "type": "Transitive",
         "resolved": "1.1.0",
         "contentHash": "aOZA3BWfz9RXjpzt0sRJJMjAscAUm3Hoa4UWAfceV9UTYxgwZ1lZt5nO2myFf+/jetYQo4uTP7zS8sJY67BBxg=="
+      },
+      "Microsoft.SourceLink.Common": {
+        "type": "Transitive",
+        "resolved": "8.0.0",
+        "contentHash": "dk9JPxTCIevS75HyEQ0E4OVAFhB2N+V9ShCXf8Q6FkUQZDkgLI12y679Nym1YqsiSysuQskT7Z+6nUf3yab6Vw=="
       },
       "Microsoft.SqlServer.Server": {
         "type": "Transitive",


### PR DESCRIPTION
Changed version of `Microsoft.SourceLink.GitHub` from `[8.0.0.0,)` to `8.0.0` in `Directory.Packages.props`. Modified `Serilog` package reference to include `Microsoft.SourceLink.GitHub` with specific asset settings in `Serilog.Enrichers.Xperience.csproj`. Updated `packages.lock.json` to reflect new versions and dependencies for `Microsoft.SourceLink.GitHub`, `Microsoft.Build.Tasks.Git`, and `Microsoft.SourceLink.Common`.